### PR TITLE
stats panel visible diff with current gun

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="They Comin"
-config/version="0.1.5"
+config/version="0.1.6"
 run/main_scene="res://levels/level_001.tscn"
 config/features=PackedStringArray("4.2", "Forward Plus")
 config/icon="res://icon.svg"

--- a/ui/gun_stats_panel.gd
+++ b/ui/gun_stats_panel.gd
@@ -7,7 +7,9 @@ extends PanelContainer
 @onready var damage: Label = %Damage
 @onready var rate_of_fire: Label = %RateOfFire
 
-
+var DEFAULT = Color(1, 1, 1)
+var RED = Color(1, 0, 0)
+var GREEN = Color(0, 1, 0)
 
 func _set_gun_stats(value: GunStats) -> void:
 	gun_stats = value
@@ -16,5 +18,16 @@ func _set_gun_stats(value: GunStats) -> void:
 		await ready
 	
 	gun_type.text = gun_stats.type_name()
-	damage.text = str(gun_stats.damage)
-	rate_of_fire.text = str(gun_stats.rate_of_fire)
+	_set_stylized_gun_stat("damage", damage, gun_stats.damage, Global.data.gun_in_hand.damage)
+	_set_stylized_gun_stat("rate", rate_of_fire, gun_stats.rate_of_fire, Global.data.gun_in_hand.rate_of_fire)
+
+func _set_stylized_gun_stat(stat_type: String, element: Label, stat: float, in_hand: float) -> void:
+	element.text = str(stat)
+	if in_hand > stat:
+		element.add_theme_color_override("font_color", RED)
+	elif in_hand < stat:
+		element.add_theme_color_override("font_color", GREEN)
+	else:
+		element.add_theme_color_override("font_color", DEFAULT)
+	
+	


### PR DESCRIPTION
This makes the gun tooltip show if stats are better than the gun in hand. Nice quality of life improvement and fixes #5 ... or at least part of it.